### PR TITLE
大佬，发现您的项目引入了org.python:jython-standalone@2.7.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -62,7 +61,7 @@
         <dependency>
             <groupId>org.python</groupId>
             <artifactId>jython-standalone</artifactId>
-            <version>2.7.0</version>
+            <version>2.7.1b3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Jython任意代码执行漏洞
缺陷组件：org.python:jython-standalone@2.7.0
漏洞编号：CVE-2016-4000
漏洞描述：Jython是在Java平台上运行的Python编程语言的实现。

Jython存在任意代码执行漏洞。允许攻击者通过专门设计的序列化PyFunction对象执行任意代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2017-22089
影响范围：(∞, 2.7.1b3)
最小修复版本：2.7.1b3
缺陷组件引入路径：com.thy:novel@0.0.1-SNAPSHOT->org.python:jython-standalone@2.7.0
```
另外我运行这个项目时，IDE的安全插件提示还有几个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p5abac